### PR TITLE
Added swagger-self-hosted.md

### DIFF
--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -19,3 +19,7 @@
     - [Built-in variables](usage-wharfyml/variables/built-in-variables.md)
     - [Input variables](usage-wharfyml/variables/input-variables.md)
     - [Evaluation order](usage-wharfyml/variables/evaluation-order.md)
+
+- Reference
+
+  - [Swagger (self-hosted)](reference/swagger-self-hosted.md)

--- a/docs/reference/swagger-self-hosted.md
+++ b/docs/reference/swagger-self-hosted.md
@@ -1,0 +1,36 @@
+# Swagger (self-hosted)
+
+Wharf's main API and provider APIs all produce OpenAPI specifications.
+
+Together with those APIs we also host Swagger to easily be able to see the exact
+API specification you have installed right now.
+
+## Main API Swagger
+
+Visit `/api/swagger/index.html` on your own self-hosted instance of Wharf.
+
+- If you host Wharf at `https://wharf.local`, then visit
+  <https://wharf.local/api/swagger/index.html>
+
+- If you're running Wharf locally on port 5000, then visit
+  <http://localhost:5000/api/swagger/index.html>
+
+## Provider APIs Swagger
+
+Visit `/import/{provider}/swagger/index.html` on your own self-hosted instance
+of Wharf, where you replace `{provider}` with the name of said provider API.
+
+Let's say you have the three providers `gitlab`, `github`, and `azuredevops`,
+then:
+
+- If you host Wharf at `https://wharf.local`, then visit
+
+  - For `gitlab` provider: <https://wharf.local/import/gitlab/swagger/index.html>
+  - For `github` provider: <https://wharf.local/import/github/swagger/index.html>
+  - For `azuredevops` provider: <https://wharf.local/import/azuredevops/swagger/index.html>
+
+- If you're running Wharf locally on port 5000, then visit
+
+  - For `gitlab` provider: <http://localhost:5000/import/gitlab/swagger/index.html>
+  - For `github` provider: <http://localhost:5000/import/github/swagger/index.html>
+  - For `azuredevops` provider: <http://localhost:5000/import/azuredevops/swagger/index.html>


### PR DESCRIPTION
> For Iver employees: WO0000000681896

Original docs from private repo was:

> ## Swagger API
>
> Go to `api/swagger/index.html` or `import/<provider>/swagger/index.html`.

I expanded it a little. Hopefully it's still comprehensible 

## Preview

https://github.com/iver-wharf/iver-wharf.github.io/blob/f443c81d5586e57fcb554f48f6aaf56cd15dd4da/docs/reference/swagger-self-hosted.md

Rendered:

![image](https://user-images.githubusercontent.com/2477952/109522143-44acb700-7aae-11eb-87c6-6e5b5a5123e3.png)
