### PR TITLE
Fixed "Documentation" link since #7

### DIFF
--- a/docs/_coverpage.md
+++ b/docs/_coverpage.md
@@ -5,4 +5,4 @@
 > Self-hosted CI/CD solution
 
 [GitHub](https://github.com/iver-wharf)
-[Documentation](#wharf-documentation)
+[Documentation](#wharf)


### PR DESCRIPTION
> For Iver employees: WO0000000681896

PR #7 changed the header name from `wharf-documentation` to simply `wharf`.

This PR fixes that.

