### PR TITLE
Added links to go docs

### DIFF
--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -28,6 +28,12 @@
 
   - [Swagger (self-hosted)](reference/swagger-self-hosted.md)
 
+  - Go reference  
+    ![Go.Dev reference](https://img.shields.io/badge/go.dev-reference-blue?logo=go&logoColor=white)
+
+    - [messagebus-go](https://pkg.go.dev/github.com/iver-wharf/messagebus-go)
+    - [wharf-api-client-go/pkg/wharfapi](https://pkg.go.dev/github.com/iver-wharf/wharf-api-client-go/pkg/wharfapi)
+
 - Development (of Wharf)
 
   - [Debugging in GoLand](development/debugging-in-goland.md)


### PR DESCRIPTION
We only have 2 so far, but it's more than none

Ive used the conventional "Go reference" icon that is used on more or less every Go repo. It's not clickable, but it amplifies the header and makes it easier to find

## Preview

![image](https://user-images.githubusercontent.com/2477952/111753227-e8f87100-8896-11eb-9d09-d908f6d958d3.png)

The external link icons are actually from a different PR. I decided to let it have its own PR: #12