### PR TITLE
Fixed coverpage "Documentation" link

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,4 +1,4 @@
-# Wharf
+# About Wharf
 
 Wharf adds the capabilities of self hosting and even running locally to the
 category of Continuous Integration and Continuous Deployment (CI/CD) tooling,

--- a/docs/_coverpage.md
+++ b/docs/_coverpage.md
@@ -5,4 +5,4 @@
 > Self-hosted CI/CD solution
 
 [GitHub](https://github.com/iver-wharf)
-[Documentation](#wharf)
+[Documentation](#about-wharf)


### PR DESCRIPTION
Coverpage linked to `#wharf`. Both the `docs/README.md` and `docs/_coverpage.md` defined a header with ID `#wharf` so when you clicked the "Documentation" button it only scrolled down to the "Wharf" header in the coverpage instead of inside the docs.

So I renamed the header inside `README.md` to be "About Wharf" (`#about-wharf`)

