### PR TITLE
Added "Getting started" dev docs

### DIFF
--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -34,7 +34,9 @@
 
 - Development (of Wharf)
 
-  - [Debugging in GoLand](development/debugging-in-goland.md)
+  - [Getting started](development/getting-started.md)
+
+  - [Debugging in GoLand](development/debugging-in-goland.md
 
   - Things to keep in mind
 

--- a/docs/_static/site.css
+++ b/docs/_static/site.css
@@ -15,6 +15,8 @@
 	--code-theme-text: var(--base-color);
 	--code-theme-selector: var(--iver-yellow);
 	--cover-blockquote-color: var(--base-color);
+
+	--docsifytabs-border-color: unset;
 }
 
 .iver-logo-wordmark,

--- a/docs/development/getting-started.md
+++ b/docs/development/getting-started.md
@@ -1,0 +1,129 @@
+# Getting started with development of Wharf
+
+## Prepare your workspace
+
+1. Install Git
+
+2. Install Docker & Docker Compose (both usually come shipped together)
+
+3. Create a folder to work in, for example named `wharf` in your personal
+   documents folder (`C:/Users/YourName/Documents` or `~/Documents`).
+
+## Clone the repositories
+
+If you're rocking terminal, you can clone them using the the following commands:
+
+<!-- tabs:start -->
+
+### **Clone via [GitHub CLI](https://github.com/cli/cli)**
+
+```bash
+gh repo clone iver-wharf/wharf-docker-compose
+gh repo clone iver-wharf/wharf-api
+gh repo clone iver-wharf/wharf-web
+gh repo clone iver-wharf/wharf-provider-gitlab
+gh repo clone iver-wharf/wharf-provider-github
+gh repo clone iver-wharf/wharf-provider-azuredevops
+```
+
+### **Clone via SSH**
+
+```bash
+git clone git@github.com:iver-wharf/wharf-docker-compose.git
+git clone git@github.com:iver-wharf/wharf-api.git
+git clone git@github.com:iver-wharf/wharf-web.git
+git clone git@github.com:iver-wharf/wharf-provider-gitlab.git
+git clone git@github.com:iver-wharf/wharf-provider-github.git
+git clone git@github.com:iver-wharf/wharf-provider-azuredevops.git
+```
+
+### **Clone via HTTPS**
+
+```bash
+git clone https://github.com/iver-wharf/wharf-docker-compose.git
+git clone https://github.com/iver-wharf/wharf-api.git
+git clone https://github.com/iver-wharf/wharf-web.git
+git clone https://github.com/iver-wharf/wharf-provider-gitlab.git
+git clone https://github.com/iver-wharf/wharf-provider-github.git
+git clone https://github.com/iver-wharf/wharf-provider-azuredevops.git
+```
+
+<!-- tabs:end -->
+
+## Link `docker-compose.yml`
+
+To run Docker Compose, it needs the `docker-compose.yml` file. This file lives
+in the <https://github.com/iver-wharf/wharf-docker-compose> repository, but
+that file cannot live inside the `wharf-docker-compose` directory as
+Docker Compose will not be able to find it.
+
+We will create a [symlink](https://en.wikipedia.org/wiki/Symbolic_link) to the
+`docker-compose.yml` file, so that when you pull new changes inside the cloned
+`wharf-docker-compose` repository directory then the symlink will also update.
+
+<!-- tabs:start -->
+
+### **UNIX (GNU/Linux, Mac OS X)**
+
+```bash
+ln -s wharf-docker-compose/docker-compose.yml docker-compose.yml
+```
+
+### **Windows `cmd.exe`**
+
+Open `cmd.exe` as an administrator, unless you have [Developer Mode](https://msdn.microsoft.com/en-us/windows/uwp/get-started/enable-your-device-for-development)
+enabled, then run:
+
+```batch
+mklink docker-compose.yml wharf-docker-compose\docker-compose.yml
+```
+
+### **Windows `PowerShell.exe`**
+
+Open PowerShell as an administrator, then run:
+
+```powershell
+New-Item -ItemType SymbolicLink -Path docker-compose.yml -Target wharf-docker-compose\docker-compose.yml
+```
+
+<!-- tabs:end -->
+
+## Build and run via Docker Compose
+
+```bash
+# Build all services in parallel
+docker-compose build --parallel
+
+# Build only 1 of the services, ex: api
+# Useful if you know only the api's code has changed
+docker-compose build api
+
+# Start running
+docker-compose up --abort-on-container-exit
+```
+
+The [`--abort-on-container-exit`](https://docs.docker.com/compose/reference/up/)
+flag is really helpful in Wharf's case to catch when a service has died, as all
+the services combined spew out a lot of logs and it's easy to miss if one of
+them has died.
+
+You can find the names of the services (used in `docker-compose build api`)
+in the `docker-compose.yml` file. At the time of writing (2021-05-10), those are
+`proxy`, `api`, `provider-gitlab`, `provider-github`, `provider-azuredevops`,
+`db`, `rabbitmq`
+
+## Accessing locally
+
+- Swagger documentation: (See [Swagger (self-hosted)](../reference/swagger-self-hosted.md))
+
+  - API: <http://localhost:5000/api/swagger/index.html>
+  - `gitlab` provider: <http://localhost:5000/import/gitlab/swagger/index.html>
+  - `github` provider: <http://localhost:5000/import/github/swagger/index.html>
+  - `azuredevops` provider: <http://localhost:5000/import/azuredevops/swagger/index.html>
+
+- Web (if enabled in `docker-compose.yml`): <http://localhost:5000/>
+
+- RabbitMQ (if enabled in `docker-compose.yml`): <http://localhost:15672/>
+
+  - Username: `guest`
+  - Password: `guest`

--- a/docs/index.html
+++ b/docs/index.html
@@ -36,10 +36,15 @@
           'View on GitHub'
         ),
       ],
+      tabs: {
+        theme: 'material'
+      }
     }
   </script>
   <!-- Additional syntax highlighting -->
   <script src="//cdn.jsdelivr.net/npm/prismjs@1/components/prism-bash.min.js"></script>
+  <script src="//cdn.jsdelivr.net/npm/prismjs@1/components/prism-powershell.min.js"></script>
+  <script src="//cdn.jsdelivr.net/npm/prismjs@1/components/prism-batch.min.js"></script>
   <script src="//cdn.jsdelivr.net/npm/prismjs@1/components/prism-diff.min.js"></script>
   <script src="//cdn.jsdelivr.net/npm/prismjs@1/components/prism-docker.min.js"></script>
   <script src="//cdn.jsdelivr.net/npm/prismjs@1/components/prism-go.min.js"></script>
@@ -57,5 +62,7 @@
   <script src="//cdn.jsdelivr.net/npm/docsify-example-panels"></script>
   <!-- Footer -->
   <script src="//cdn.jsdelivr.net/npm/@alertbox/docsify-footer/dist/docsify-footer.min.js"></script>
+  <!-- docsify-tabs -->
+  <script src="https://cdn.jsdelivr.net/npm/docsify-tabs@1"></script>
 </body>
 </html>


### PR DESCRIPTION
I've just added the repos:

- https://github.com/iver-wharf/wharf-docker-compose
- https://github.com/iver-wharf/wharf-api
- https://github.com/iver-wharf/wharf-web

Now we can finally have docs on how to start running Wharf locally.

These are just rewritten docs from our old internal docs repo. I added dependency on [Docsify-Tabs](https://jhildenbiddle.github.io/docsify-tabs), and it looks like this:

![Peek 2021-05-10 13-01](https://user-images.githubusercontent.com/2477952/117649533-ebd55b00-b18f-11eb-954e-b71fb1b7b0ec.gif)
