### PR TITLE
Remaining /prob/ docs

### DIFF
--- a/docs/prob/api/internal-server-error.md
+++ b/docs/prob/api/internal-server-error.md
@@ -16,7 +16,7 @@ gone terribly wrong that the API does not recognise then this error is reported.
 
 ## Possible causes
 
-If a Go panic occurrs in one of the endpoints, then the API will quickly
+If a Go panic occurs in one of the endpoints, then the API will quickly
 recover, return a `/prob/api/internal-server-error` response to the client,
 and then most probably shutdown.
 

--- a/docs/prob/api/invalid-param.md
+++ b/docs/prob/api/invalid-param.md
@@ -1,0 +1,54 @@
+# Problem: Invalid API parameter
+
+<!-- panels:start -->
+
+<!-- div:right-panel -->
+
+- Title: `Invalid API parameter.`
+- Type: `/prob/api/invalid-param`
+
+<!-- div:left-panel -->
+
+Parsing or validating a value sent to the API failed.
+
+<!-- panels:end -->
+
+## Possible causes
+
+<!-- panels:start -->
+
+<!-- div:left-panel -->
+
+Most fields are validated in the frontend, but if you're calling the backend API
+directly or if there is some validation rule missing in the frontend, then this
+problem may arise.
+
+The problem is related to the backend trying to parse or validate an input value
+but fails because of an invalid value.
+
+This problem is the fallback error for any special parameter types. Meaning,
+that this problem does not describe in detail which field was invalid or in what
+way it was considered invalid.
+
+<!-- div:right-panel -->
+
+Non-exhaustive list of potential issues:
+
+- invalid date format,
+- text string that is too long or too short (too many or too few characters),
+- URL that's missing the protocol (`https://`),
+- submitting "F" when only "A", "B", or "C" is allowed,
+- *or potentially something divergent from the above.*
+
+<!-- panels:end -->
+
+## Resolving it
+
+The problem detail message that is provided by the error message should be able
+to lead you to understanding the issue at hands.
+
+If you cannot resolve it yourself using the error message, try to contact your
+administrator / operations team that manages your Wharf instance.
+
+If that fails, try promoting the issue over to the Wharf developers over at
+GitHub as an issue: <https://github.com/iver-wharf/wharf-api/issues/new>

--- a/docs/prob/api/missing-param-string.md
+++ b/docs/prob/api/missing-param-string.md
@@ -1,0 +1,47 @@
+# Problem: Missing string value
+
+<!-- panels:start -->
+
+<!-- div:right-panel -->
+
+- Title: `Missing string value.`
+- Type: `/prob/api/missing-param-string`
+
+<!-- div:left-panel -->
+
+A text string was omitted or left empty in a web request.
+
+<!-- panels:end -->
+
+## Possible causes
+
+<!-- panels:start -->
+
+<!-- div:left-panel -->
+
+Most fields are validated in the frontend, but if you're calling the backend API
+directly or if there is some validation rule missing in the frontend, then this
+problem may arise.
+
+The problem is related to the backend expecting a string (text) value but
+received none, or that the received string was empty (zero length).
+
+<!-- div:right-panel -->
+
+For example, if you started a new build, but the name of the stage to run did
+not get sent (due to bug in the web page), then the API server could respond
+with:
+
+> **Missing string value.** \
+> A string value (text) was expected on parameter "stage", but it was either
+> omitted or empty.
+
+<!-- panels:end -->
+
+## Resolving it
+
+If you cannot resolve it yourself using the error message, try to contact your
+administrator / operations team that manages your Wharf instance.
+
+If that fails, try promoting the issue over to the Wharf developers over at
+GitHub as an issue: <https://github.com/iver-wharf/wharf-api/issues/new>

--- a/docs/prob/api/project/cannot-change-group.md
+++ b/docs/prob/api/project/cannot-change-group.md
@@ -1,0 +1,40 @@
+# Problem: Project group cannot be changed
+
+<!-- panels:start -->
+
+<!-- div:right-panel -->
+
+- Title: `Project group cannot be changed.`
+- Type: `/prob/api/project/cannot-change-group`
+
+<!-- div:left-panel -->
+
+Once a project has been imported into Wharf, it is not allowed to have its group
+changed.
+
+<!-- panels:end -->
+
+## Possible causes
+
+This occurs when you update the group field on a project.
+
+There are some things that are locked in projects and cannot be changed. The
+project ID and project group name, to name a few.
+
+The project group field cannot be updated manually through Wharf's web interface
+on its own, but if you were to move a project from one user to another, or from
+one GitHub organization to another, followed by refreshing the project, then
+this problem could appear.
+
+## Resolving it
+
+Try importing the project from scratch, instead of trying to refresh the already
+imported project.
+
+If you receive the same error when importing from scratch, then you would need
+to delete the project from Wharf's database. As of the time of writing
+(2021-05-18), that would be done by sending an HTTP
+`DELETE /api/project/{projectid}` request to Wharf's API.
+
+If that fails, try promoting the issue over to the Wharf developers over at
+GitHub as an issue: <https://github.com/iver-wharf/wharf-api/issues/new>

--- a/docs/prob/api/project/run/params-deserialize.md
+++ b/docs/prob/api/project/run/params-deserialize.md
@@ -1,0 +1,59 @@
+# Problem: Parsing build parameters failed
+
+<!-- panels:start -->
+
+<!-- div:right-panel -->
+
+- Title: `Parsing build parameters failed.`
+- Type: `/prob/api/project/run/params-deserialize`
+
+<!-- div:left-panel -->
+
+Failed to parse build input parameters when starting a new build.
+
+<!-- panels:end -->
+
+## Possible causes
+
+<!-- panels:start -->
+
+<!-- div:left-panel -->
+
+Most fields are validated in the frontend, but if you're calling the backend API
+directly or if there is some validation rule missing in the frontend, then this
+problem may arise.
+
+Each build allows optional input parameters/[input variables](/usage-wharfyml/variables/input-variables.md)
+if they are defined in the projects [`.wharf-ci.yml`](/usage-wharfyml/) file.
+When starting a new build, you are allowed to set custom values for these
+variables on a per-build basis.
+
+If Wharf's API fails to parse these values that you've sent it, or fails to
+parse the input variable definitions of the project's build definition
+(`.wharf-ci.yml` file) itself, then this problem may arise.
+Such as if the value types of the input variables you've sent along or if the
+HTTP request payload is malformed.
+
+<!-- div:right-panel -->
+
+Examples:
+
+- The value `"foo bar"` is sent as the value for a `number`-typed input variable. 
+
+- HTTP request body to `POST /api/project/{projectid}/{stage}/run` is invalid
+  JSON or empty.
+
+<!-- panels:end -->
+
+## Resolving it
+
+In the case that you've entered a type of invalid format (ex: text string where
+a number of solely digits was expected) in Wharf's web interface then you can
+correct your mistake and try again. It would behoove us if you also reported the
+issue to the frontend GitHub repository as an issue: <https://github.com/iver-wharf/wharf-web/issues/new>
+
+If you cannot resolve it yourself using the error message, try to contact your
+administrator / operations team that manages your Wharf instance.
+
+If that fails, try promoting the issue over to the Wharf developers over at
+GitHub as an issue: <https://github.com/iver-wharf/wharf-api/issues/new>

--- a/docs/prob/api/project/run/params-serialize.md
+++ b/docs/prob/api/project/run/params-serialize.md
@@ -1,0 +1,38 @@
+# Problem: Serializing build parameters failed
+
+<!-- panels:start -->
+
+<!-- div:right-panel -->
+
+- Title: `Serializing build parameters failed.`
+- Type: `/prob/api/project/run/params-serialize`
+
+<!-- div:left-panel -->
+
+Failed to compose build parameters to be forwarded to the execution engine when
+starting a new build.
+
+<!-- panels:end -->
+
+## Possible causes
+
+It's uncommon for Wharf's API to fail at this stage, but it comes from when it
+prepares the values it needs to send to the execution engine. This involves more
+than just the optional input parameters/[input variables](/usage-wharfyml/variables/input-variables.md)
+that you submit when starting a new build, but also a lot of other data such as
+the build ID, project name, Git clone URL, et.al.
+
+This usually means there has been a bug or regression in the Wharf API's
+codebase which lead it to produce this error.
+
+If Wharf's API fails to parse the values that you've sent it, then you are
+instead presented with the [`/prob/api/project/run/params-deserialize`](/prob/api/project/run/params-deserialize)
+problem.
+
+## Resolving it
+
+If you cannot resolve it yourself using the error message, try to contact your
+administrator / operations team that manages your Wharf instance.
+
+If that fails, try promoting the issue over to the Wharf developers over at
+GitHub as an issue: <https://github.com/iver-wharf/wharf-api/issues/new>

--- a/docs/prob/api/project/run/trigger.md
+++ b/docs/prob/api/project/run/trigger.md
@@ -1,0 +1,57 @@
+# Problem: Triggering build failed
+
+<!-- panels:start -->
+
+<!-- div:right-panel -->
+
+- Title: `Triggering build failed.`
+- Type: `/prob/api/project/run/trigger`
+
+<!-- div:left-panel -->
+
+Wharf's API failed to communicate with the execution engine and tell it to start
+executing the build.
+
+<!-- panels:end -->
+
+## Possible causes
+
+<!-- panels:start -->
+
+<!-- div:left-panel -->
+
+There are plentyful of reasons why the Wharf API has been unable to talk with
+the execution engine. Most of these issues are operations-related, meaning that
+it's something with how your Wharf installation has been set up.
+
+Potential causes ranges from network issues, to TLS/certificate issues, or even
+as mundane issues such as someone accidentally shut it off.
+
+<!-- div:right-panel -->
+
+Examples:
+
+- Execution engine was offline when the Wharf API tried to communicate with it
+  (ex: restarting, failed to start, or being relocated to a different server by
+  [Kubernetes' evicion policies](https://kubernetes.io/docs/concepts/scheduling-eviction/eviction-policy/))
+  
+- Execution engine was never deployed. Wether you're using [Jenkins](https://www.jenkins.io/)
+  or Wharf's own execution engine, if you never deployed it then no builds can
+  be started.
+
+- Execution engine is misconfigured and responded with a
+  [non-2xx status code.](https://en.wikipedia.org/wiki/List_of_HTTP_status_codes#2xx_success)
+  
+- Network issues between the execution engine and the Wharf API processes.
+  Perhaps a misconfigured firewall or network policy.
+
+<!-- panels:end -->
+
+## Resolving it
+
+This is out of scope for any user that solely reaches either Wharf's web
+interface or REST API. Suggest you try to contact your
+administrator / operations team that manages your Wharf instance.
+
+If that fails, try promoting the issue over to the Wharf developers over at
+GitHub as an issue: <https://github.com/iver-wharf/wharf-api/issues/new>

--- a/docs/prob/api/provider/invalid-name.md
+++ b/docs/prob/api/provider/invalid-name.md
@@ -1,0 +1,55 @@
+# Problem: Invalid provider name
+
+<!-- panels:start -->
+
+<!-- div:right-panel -->
+
+- Title: `Invalid provider name.`
+- Type: `/prob/api/provider/invalid-name`
+
+<!-- div:left-panel -->
+
+Name of provider was not one of the supported/enabled providers.
+
+<!-- panels:end -->
+
+## Possible causes
+
+<!-- panels:start -->
+
+<!-- div:left-panel -->
+
+When a provider tries to register some projects but the name that the provider
+says it has is not in the valid set of provider names.
+
+At the time of writing (2021-05-19, with Wharf API v4.0.0 in development) it is
+still locked to only supporting a narrow set of provider names.
+
+<!-- div:right-panel -->
+
+:heavy_check_mark: Example valid inputs (as of Wharf API v4.0.0):
+
+- `github`
+- `gitlab`
+- `azuredevops`
+
+:x: Example invalid inputs:
+
+- ` ` *(empty value)*
+- `GitHub` *(must be lower-cased)*
+- `gitea` *(is not one of the above 3 valid provider names)*
+
+<!-- panels:end -->
+
+## Resolving it
+
+As a developer of the provider, you can make sure you are passing along one of
+the valid provider names listed above.
+
+If you are not a developer of the provider you are trying to use, then please
+report this issue to the developers. For the provider components developed by
+Iver you would create a new issue over at:
+
+- GitHub provider: <https://github.com/iver-wharf/wharf-provider-github/issues/new>
+- GitLab provider: <https://github.com/iver-wharf/wharf-provider-gitlab/issues/new>
+- Azure DevOps provider: <https://github.com/iver-wharf/wharf-provider-azuredevops/issues/new>

--- a/docs/prob/api/record-not-found.md
+++ b/docs/prob/api/record-not-found.md
@@ -1,0 +1,58 @@
+# Problem: Record not found
+
+<!-- panels:start -->
+
+<!-- div:right-panel -->
+
+- Title: `Record not found.`
+- Type: `/prob/api/record-not-found`
+
+<!-- div:left-panel -->
+
+A record (peice of data) that does not exist was attempted to be fetched from
+the database.
+
+<!-- panels:end -->
+
+## Possible causes
+
+<!-- panels:start -->
+
+<!-- div:left-panel -->
+
+There are plenty of ways a "Record not found" problem may arise. The outline
+is that you are trying to find a peice of data based on some unique identifier
+(ID) that does not exist.
+
+Most probably no true damage has been done here. Just that the resource you're
+looking for cannot be found. Such as if you've made a typo in the URL or some
+bug in the UI.
+
+This is what is commonly known as the "404 error", as [the status code 404
+stands for "Not Found" on the web.](https://en.wikipedia.org/wiki/HTTP_404)
+
+<!-- div:right-panel -->
+
+Examples:
+
+- Show details for project with ID `123`, when no such project exists.
+
+- Download artifact with ID `456` from build with ID `123`, when no such
+  artifact or build exists.
+
+- Download artifact that has since been removed due to disk space shortage.
+
+- You followed an old link but the database has since been cleared.
+
+<!-- panels:end -->
+
+## Resolving it
+
+If you followed a hyperlink from outside of the Wharf web interface then it
+would be wise to correct that foreign URL, if able.
+
+If you cannot resolve it yourself using the error message, try to contact your
+administrator / operations team that manages your Wharf instance.
+
+If that fails, try promoting the issue over to the Wharf developers over at
+GitHub as an issue: <https://github.com/iver-wharf/wharf-api/issues/new>

--- a/docs/prob/api/unexpected-body-read-error.md
+++ b/docs/prob/api/unexpected-body-read-error.md
@@ -1,0 +1,35 @@
+# Problem: Error reading request body
+
+<!-- panels:start -->
+
+<!-- div:right-panel -->
+
+- Title: `Error reading request body.`
+- Type: `/prob/api/unexpected-body-read-error`
+
+<!-- div:left-panel -->
+
+Wharf's API failed to read the body of the HTTP request.
+
+<!-- panels:end -->
+
+## Possible causes
+
+A manually composed HTTP request might trigger this error. Nothing that should
+be able to occur from regular use of Wharf's web interface or even a code
+library used to talk with Wharf's API directly.
+
+There is a chance the network drops during the request and Wharf's API never
+receives the HTTP body it wants to read from, but by then a problem message
+response should not be able to get transmitted back to the client.
+
+Therefore this problem will most probably only be observed through the Wharf
+API's logs.
+
+## Resolving it
+
+Try to contact your administrator / operations team that manages your Wharf
+instance, as this might have some network issues implications.
+
+If that fails, try promoting the issue over to the Wharf developers over at
+GitHub as an issue: <https://github.com/iver-wharf/wharf-api/issues/new>

--- a/docs/prob/api/unexpected-db-read-error.md
+++ b/docs/prob/api/unexpected-db-read-error.md
@@ -1,0 +1,54 @@
+# Problem: Error reading from database
+
+<!-- panels:start -->
+
+<!-- div:right-panel -->
+
+- Title: `Error reading from database.`
+- Type: `/prob/api/unexpected-db-read-error`
+
+<!-- div:left-panel -->
+
+Wharf's API failed to perform read operations on the database to obtain data.
+
+<!-- panels:end -->
+
+## Possible causes
+
+<!-- panels:start -->
+
+<!-- div:left-panel -->
+
+Communication from Wharf's API to the database is crucial to keep alive, but
+when it fails then this problem may arise.
+
+This problem suggests that a read operation failed, such as when you visit the
+details page of a project.
+
+In contrast to the [`/prob/api/unexpected-db-write-error`](/prob/api/unexpected-db-write-error)
+problem, reading can usually be performed even if the database has ran out of
+disk space.
+
+<!-- div:right-panel -->
+
+Examples:
+
+- Network issues.
+- Database is offline due to restarting.
+
+:x: Should not be affected by:
+
+- Database has reached maximum disk capacity.
+
+<!-- panels:end -->
+
+## Resolving it
+
+Try again later. Most probably the issue is a fluke and retrying instantly or
+after a few minutes usually resolves the issue.
+
+If the issue remains, try to contact your administrator / operations team that
+manages your Wharf instance.
+
+If that fails, try promoting the issue over to the Wharf developers over at
+GitHub as an issue: <https://github.com/iver-wharf/wharf-api/issues/new>

--- a/docs/prob/api/unexpected-db-write-error.md
+++ b/docs/prob/api/unexpected-db-write-error.md
@@ -1,0 +1,57 @@
+# Problem: Error reading from database
+
+<!-- panels:start -->
+
+<!-- div:right-panel -->
+
+- Title: `Error writing to database.`
+- Type: `/prob/api/unexpected-db-write-error`
+
+<!-- div:left-panel -->
+
+Wharf's API failed to perform write operations on the database to add or update
+data.
+
+<!-- panels:end -->
+
+## Possible causes
+
+<!-- panels:start -->
+
+<!-- div:left-panel -->
+
+Communication from Wharf's API to the database is crucial to keep alive, but
+when it fails then this problem may arise.
+
+This problem suggests that a write operation failed, such as when you start a
+new build and the Wharf API needs to store the state of this new build in the
+database.
+
+If the database has ran out of disk space, it's common for them to enter
+"read-only" mode where read operations are allowed but write operations are
+not. Even updates and deletions, which could even shrink the database size, are
+usually disallowed in "read-only" mode.
+
+<!-- div:right-panel -->
+
+Examples:
+
+- Network issues.
+- Database is offline due to restarting.
+- Database has reached maximum disk capacity.
+
+<!-- panels:end -->
+
+## Resolving it
+
+If you can deduce from the error message that the issue regards network issues
+and not disk space, then you could try again after a short while and it should
+probably work that time, given that the network issue might have been a fluke.
+
+Otherwise, try to contact your administrator / operations team that manages
+your Wharf instance. They may have to increase the database disk size as
+removing old data is usually prohibited when the database has entered
+"read-only" mode due to disk space shortage.
+
+If that fails, try promoting the issue over to the Wharf developers over at
+GitHub as an issue: <https://github.com/iver-wharf/wharf-api/issues/new>

--- a/docs/prob/api/unexpected-multipart-read-error.md
+++ b/docs/prob/api/unexpected-multipart-read-error.md
@@ -1,0 +1,42 @@
+# Problem: Error reading multipart data
+
+<!-- panels:start -->
+
+<!-- div:right-panel -->
+
+- Title: `Error reading multipart data.`
+- Type: `/prob/api/unexpected-multipart-read-error`
+
+<!-- div:left-panel -->
+
+Wharf's API failed to read the multipart body of the HTTP request.
+
+<!-- panels:end -->
+
+## Possible causes
+
+A manually composed HTTP request might trigger this error. Nothing that should
+be able to occur from regular use of Wharf's web interface or even a code
+library used to talk with Wharf's API directly.
+
+In contrast to the quite similar [`/prob/api/unexpected-body-read-error`](/prob/api/unexpected-body-read-error)
+problem, this problem can be produced from a malformed HTTP request.
+
+Wharf's API expected a request with the header `Content-Type: multipart/*`
+(such as `Content-Type: multipart/form-data`) and an appropriately structured
+HTTP request body. If any of those does not match what the API endpoint
+expected then Wharf's API will fail to read said data.
+
+Example endpoint that could produce this is the endpoint for uploading
+artifacts for a build.
+
+## Resolving it
+
+This issue most probably resides in the library or interface you are using. If
+you are getting this problem in Wharf's web interface, then please report it
+to the Wharf developers over at GitHub as an issue: <https://github.com/iver-wharf/wharf-web/issues/new>
+
+If you are using a library or perhaps receving the problem when trying to
+upload artifacts through a Wharf build then please report it to the appropriate
+developers. If you are uncertain, you can create a GitHub issue at:
+<https://github.com/iver-wharf/wharf-api/issues/new>

--- a/docs/prob/build/run/invalid-input.md
+++ b/docs/prob/build/run/invalid-input.md
@@ -1,0 +1,27 @@
+# Problem: Invalid input variable for build
+
+<!-- panels:start -->
+
+<!-- div:right-panel -->
+
+- Title: `Invalid input variable for build.`
+- Type: `/prob/build/run/invalid-input`
+
+<!-- div:left-panel -->
+
+An [input variable](/usage-wharfyml/variables/input-variables.md) is invalid
+and was denied in its current form when starting a new build.
+
+<!-- panels:end -->
+
+## Possible causes
+
+This problem is not in active use by Wharf, but is as of today (2021-05-19)
+only referenced in unit and example tests inside the [iver-wharf/wharf-api](https://github.com/iver-wharf/wharf-api)
+repository, as well as in documentation as a sample problem.
+
+## Resolving it
+
+If you spot this problem in a production environment, please report it to our
+documentation repository over at GitHub as an issue so we can update this page:
+<https://github.com/iver-wharf/iver-wharf.github.io/issues/new>

--- a/docs/prob/problem-template.md
+++ b/docs/prob/problem-template.md
@@ -15,7 +15,24 @@ Short description of problem.
 
 ## Possible causes
 
+<!-- panels:start -->
+
+<!-- div:left-panel -->
+
 When does this problem occurr?
+
+<!-- div:right-panel -->
+
+:heavy_check_mark: Example valid inputs:
+
+- Input is A
+- Input is B
+
+:x: Example invalid inputs:
+
+- Input is C
+
+<!-- panels:end -->
 
 ## Resolving it
 

--- a/docs/prob/problem-template.md
+++ b/docs/prob/problem-template.md
@@ -19,7 +19,7 @@ Short description of problem.
 
 <!-- div:left-panel -->
 
-When does this problem occurr?
+When does this problem occur?
 
 <!-- div:right-panel -->
 


### PR DESCRIPTION
New problem pages:

- /prob/api/invalid-param
- /prob/api/missing-param-string
- /prob/api/project/cannot-change-group
- /prob/api/project/run/params-deserialize
- /prob/api/project/run/params-serialize
- /prob/api/project/run/trigger
- /prob/api/provider/invalid-name
- /prob/api/record-not-found
- /prob/api/unexpected-body-read-error
- /prob/api/unexpected-db-read-error
- /prob/api/unexpected-db-write-error
- /prob/build/run/invalid-input
- /prob/api/unexpected-multipart-read-error

Other changes:

- Added example to problem template

---

Closes #23
