### PR TITLE
Replaced wharf-api reference with wharf-core

### DIFF
--- a/docs/reference/_sidebar.md
+++ b/docs/reference/_sidebar.md
@@ -9,7 +9,7 @@
 
     - [messagebus-go](https://pkg.go.dev/github.com/iver-wharf/messagebus-go)
     - [wharf-api-client-go/pkg/wharfapi](https://pkg.go.dev/github.com/iver-wharf/wharf-api-client-go/pkg/wharfapi)
-    - [wharf-api](https://pkg.go.dev/github.com/iver-wharf/wharf-api)
+    - [wharf-core](https://pkg.go.dev/github.com/iver-wharf/wharf-core)
 
 - [Problems](prob/)
 


### PR DESCRIPTION
The `wharf-api` repo is not a library so it doesn't make much sense to have its reference docs link here.

The `wharf-core` repo is new, so that one gets to be here now
