### PR TITLE
Added documentation for wharf-provider-github error responses

### DIFF
--- a/docs/prob/_sidebar.md
+++ b/docs/prob/_sidebar.md
@@ -20,5 +20,10 @@
   - [/prob/api/unexpected-db-write-error](/prob/api/unexpected-db-write-error.md)
   - [/prob/api/unexpected-multipart-read-error](/prob/api/unexpected-multipart-read-error.md)
   - [/prob/build/run/invalid-input](/prob/build/run/invalid-input.md)
+  - [/prob/provider/github/connection-error](/prob/provider/github/connection-error.md)
+  - [/prob/provider/github/getting-provider-error](/prob/provider/github/getting-provider-error.md)
+  - [/prob/provider/github/getting-token-error](/prob/provider/github/getting-token-error.md)
+  - [/prob/provider/github/import-group-error](/prob/provider/github/import-group-error.md)
+  - [/prob/provider/github/import-project-error](/prob/provider/github/import-project-error.md)
 
 - [Development (of Wharf)](development/)

--- a/docs/prob/provider/github/connection-error.md
+++ b/docs/prob/provider/github/connection-error.md
@@ -1,4 +1,4 @@
-# Problem: Error connecting to GitHub.
+# Problem: Error connecting to GitHub
 
 <!-- panels:start -->
 

--- a/docs/prob/provider/github/connection-error.md
+++ b/docs/prob/provider/github/connection-error.md
@@ -1,0 +1,30 @@
+# Problem: Error connecting to GitHub.
+
+<!-- panels:start -->
+
+<!-- div:right-panel -->
+
+- Title: `Error connecting to GitHub.`
+- Type: `/prob/provider/github/connection-error`
+
+<!-- div:left-panel -->
+
+Unable to initiate connection to GitHub.
+
+<!-- panels:end -->
+
+## Possible causes
+
+<!-- panels:start -->
+
+The token might be invalid.
+
+<!-- panels:end -->
+
+## Resolving it
+
+If you cannot resolve it yourself using the error message, try to contact your
+administrator / operations team that manages your Wharf instance.
+
+If that fails, try promoting the issue over to the Wharf developers over at
+GitHub as an issue: <https://github.com/iver-wharf/wharf-api/issues/new>

--- a/docs/prob/provider/github/connection-error.md
+++ b/docs/prob/provider/github/connection-error.md
@@ -27,4 +27,4 @@ If you cannot resolve it yourself using the error message, try to contact your
 administrator / operations team that manages your Wharf instance.
 
 If that fails, try promoting the issue over to the Wharf developers over at
-GitHub as an issue: <https://github.com/iver-wharf/wharf-api/issues/new>
+GitHub as an issue: <https://github.com/iver-wharf/wharf-provider-github/issues/new>

--- a/docs/prob/provider/github/getting-provider-error.md
+++ b/docs/prob/provider/github/getting-provider-error.md
@@ -29,4 +29,4 @@ If you cannot resolve it yourself using the error message, try to contact your
 administrator / operations team that manages your Wharf instance.
 
 If that fails, try promoting the issue over to the Wharf developers over at
-GitHub as an issue: <https://github.com/iver-wharf/wharf-api/issues/new>
+GitHub as an issue: <https://github.com/iver-wharf/wharf-provider-github/issues/new>

--- a/docs/prob/provider/github/getting-provider-error.md
+++ b/docs/prob/provider/github/getting-provider-error.md
@@ -1,0 +1,32 @@
+# Problem: Error getting provider
+
+<!-- panels:start -->
+
+<!-- div:right-panel -->
+
+- Title: `Error getting GitHub provider.`
+- Type: `/prob/provider/getting-provider-error`
+
+<!-- div:left-panel -->
+
+Getting GitHub provider failed.
+
+<!-- panels:end -->
+
+## Possible causes
+
+<!-- panels:start -->
+
+- A provider with the specified id was not found.
+- The url did not match the provider url.
+- The upload url did not match the provider upload url.
+
+<!-- panels:end -->
+
+## Resolving it
+
+If you cannot resolve it yourself using the error message, try to contact your
+administrator / operations team that manages your Wharf instance.
+
+If that fails, try promoting the issue over to the Wharf developers over at
+GitHub as an issue: <https://github.com/iver-wharf/wharf-api/issues/new>

--- a/docs/prob/provider/github/getting-token-error.md
+++ b/docs/prob/provider/github/getting-token-error.md
@@ -1,4 +1,4 @@
-# Problem: Error getting token.
+# Problem: Error getting token
 
 <!-- panels:start -->
 

--- a/docs/prob/provider/github/getting-token-error.md
+++ b/docs/prob/provider/github/getting-token-error.md
@@ -1,0 +1,30 @@
+# Problem: Error getting token.
+
+<!-- panels:start -->
+
+<!-- div:right-panel -->
+
+- Title: `Error getting token.`
+- Type: `/prob/provider/github/getting-token-error`
+
+<!-- div:left-panel -->
+
+Unable to get a valid token.
+
+<!-- panels:end -->
+
+## Possible causes
+
+<!-- panels:start -->
+
+This problem normally occurs if the token is not configured properly.
+
+<!-- panels:end -->
+
+## Resolving it
+
+If you cannot resolve it yourself using the error message, try to contact your
+administrator / operations team that manages your Wharf instance.
+
+If that fails, try promoting the issue over to the Wharf developers over at
+GitHub as an issue: <https://github.com/iver-wharf/wharf-api/issues/new>

--- a/docs/prob/provider/github/getting-token-error.md
+++ b/docs/prob/provider/github/getting-token-error.md
@@ -27,4 +27,4 @@ If you cannot resolve it yourself using the error message, try to contact your
 administrator / operations team that manages your Wharf instance.
 
 If that fails, try promoting the issue over to the Wharf developers over at
-GitHub as an issue: <https://github.com/iver-wharf/wharf-api/issues/new>
+GitHub as an issue: <https://github.com/iver-wharf/wharf-provider-github/issues/new>

--- a/docs/prob/provider/github/import-group-error.md
+++ b/docs/prob/provider/github/import-group-error.md
@@ -17,7 +17,8 @@ Unable to import group from GitHub.
 
 <!-- panels:start -->
 
-Occurs when there was an error getting the groups or when putting the projects/branches to Wharf.
+Occurs when there was an error getting the groups or when putting the
+projects/branches to Wharf.
 
 <!-- panels:end -->
 

--- a/docs/prob/provider/github/import-group-error.md
+++ b/docs/prob/provider/github/import-group-error.md
@@ -28,4 +28,4 @@ If you cannot resolve it yourself using the error message, try to contact your
 administrator / operations team that manages your Wharf instance.
 
 If that fails, try promoting the issue over to the Wharf developers over at
-GitHub as an issue: <https://github.com/iver-wharf/wharf-api/issues/new>
+GitHub as an issue: <https://github.com/iver-wharf/wharf-provider-github/issues/new>

--- a/docs/prob/provider/github/import-group-error.md
+++ b/docs/prob/provider/github/import-group-error.md
@@ -1,0 +1,30 @@
+# Problem: Error importing group from GitHub
+
+<!-- panels:start -->
+
+<!-- div:right-panel -->
+
+- Title: `Error importing group from GitHub.`
+- Type: `/prob/provider/github/import-group-error`
+
+<!-- div:left-panel -->
+
+Unable to import group from GitHub.
+
+<!-- panels:end -->
+
+## Possible causes
+
+<!-- panels:start -->
+
+Occurs when there was an error getting the groups or when putting the projects/branches to Wharf.
+
+<!-- panels:end -->
+
+## Resolving it
+
+If you cannot resolve it yourself using the error message, try to contact your
+administrator / operations team that manages your Wharf instance.
+
+If that fails, try promoting the issue over to the Wharf developers over at
+GitHub as an issue: <https://github.com/iver-wharf/wharf-api/issues/new>

--- a/docs/prob/provider/github/import-project-error.md
+++ b/docs/prob/provider/github/import-project-error.md
@@ -1,0 +1,30 @@
+# Problem: Error importing project from GitHub
+
+<!-- panels:start -->
+
+<!-- div:right-panel -->
+
+- Title: `Error importing project from GitHub.`
+- Type: `/prob/provider/github/import-project-error`
+
+<!-- div:left-panel -->
+
+Unable to import project from GitHub.
+
+<!-- panels:end -->
+
+## Possible causes
+
+<!-- panels:start -->
+
+Most likely the specified project name or id did not match any existing project.
+
+<!-- panels:end -->
+
+## Resolving it
+
+If you cannot resolve it yourself using the error message, try to contact your
+administrator / operations team that manages your Wharf instance.
+
+If that fails, try promoting the issue over to the Wharf developers over at
+GitHub as an issue: <https://github.com/iver-wharf/wharf-api/issues/new>

--- a/docs/prob/provider/github/import-project-error.md
+++ b/docs/prob/provider/github/import-project-error.md
@@ -27,4 +27,4 @@ If you cannot resolve it yourself using the error message, try to contact your
 administrator / operations team that manages your Wharf instance.
 
 If that fails, try promoting the issue over to the Wharf developers over at
-GitHub as an issue: <https://github.com/iver-wharf/wharf-api/issues/new>
+GitHub as an issue: <https://github.com/iver-wharf/wharf-provider-github/issues/new>


### PR DESCRIPTION
Closes #56 

- Added documentation for error responses (https://github.com/iver-wharf/wharf-provider-github/pull/16)
