### PR TITLE
Added docs on understanding changelogs

### DIFF
--- a/docs/development/_sidebar.md
+++ b/docs/development/_sidebar.md
@@ -8,11 +8,17 @@
 
   - [Getting started](development/getting-started.md)
 
-  - [Hot reloading web](development/hot-reloading-web.md)
+  - Guides
 
-  - [RFCs (Request For Comments)](https://iver-wharf.github.io/rfcs)
+    - [Changelog](development/changelogs/)
 
-  - [Debugging in GoLand](development/debugging-in-goland.md)
+    - [RFCs (Request For Comments)](https://iver-wharf.github.io/rfcs)
+
+  - Tips and tricks
+
+    - [Hot reloading web](development/hot-reloading-web.md)
+
+    - [Debugging in GoLand](development/debugging-in-goland.md)
 
   - Things to keep in mind
 

--- a/docs/development/_sidebar.md
+++ b/docs/development/_sidebar.md
@@ -14,8 +14,6 @@
 
     - [RFCs (Request For Comments)](https://iver-wharf.github.io/rfcs)
 
-  - Tips and tricks
-
     - [Hot reloading web](development/hot-reloading-web.md)
 
     - [Debugging in GoLand](development/debugging-in-goland.md)

--- a/docs/development/changelogs/README.md
+++ b/docs/development/changelogs/README.md
@@ -5,7 +5,7 @@ In all of our repositories (except for the solely documentation ones) we have a
 implemented the respective change.
 
 This document is a guide on how to interpret those files, as well as understand
-why we, the Wharf developers, has decided to use them in the way we do.
+why we, the Wharf developers, have decided to use them in the way we do.
 
 When composing your own changelogs, such as when you're submitting a pull
 request to one of our GitHub repositories, we expect that you've read our guide
@@ -14,7 +14,7 @@ on [writing changelogs](development/changelogs/writing-changelogs.md) first.
 ## What it looks like
 
 Each `CHANGELOG.md` includes a list of versions and the date they were
-released, or the text `(WIP)` if the notes declares changes that has not yet
+released, or the text `(WIP)` if the notes declare changes that have not yet
 been released.
 
 Each version holds a list of notes declaring if something has been added,

--- a/docs/development/changelogs/README.md
+++ b/docs/development/changelogs/README.md
@@ -1,0 +1,104 @@
+# Changelogs
+
+In all of our repositories (except for the solely documentation ones) we have a
+`CHANGELOG.md` file that contains notes written by the developers who
+implemented the respective change.
+
+This document is a guide on how to interpret those files, as well as understand
+why we, the Wharf developers, has decided to use them in the way we do.
+
+When composing your own changelogs, such as when you're submitting a pull
+request to one of our GitHub repositories, we expect that you've read our guide
+on [writing changelogs](development/changelogs/writing-changelogs.md) first.
+
+## What it looks like
+
+Each `CHANGELOG.md` includes a list of versions and the date they were
+released, or the text `(WIP)` if the notes declares changes that has not yet
+been released.
+
+Each version holds a list of notes declaring if something has been added,
+changed, fixed, removed, or deprecated, as well as a reference to the GitHub
+pull request(s) where the change was implemented.
+
+<!-- panels:start -->
+
+<!-- div:left-panel -->
+
+Here's a sample source code view of what a `CHANGELOG.md` file might include:
+
+```markdown
+# Changelog for fake-project
+
+## v1.1.0 (2021-05-13)
+
+- Added new tab to the top bar menu. (#15)
+
+- Changed version of database library from v3.0.0 to v3.1.0. (#16)
+
+- Fixed bug where page would refresh after 3 minutes. (#17, #18)
+
+## v1.0.0 (2021-03-03)
+
+- Added reworked GUI. Enjoy the new design! (#10)
+```
+
+<!-- div:right-panel -->
+
+The sample markdown would be rendered as:
+
+> ### Changelog for fake-project <!-- {docsify-ignore} -->
+> 
+> #### v1.1.0 (2021-05-13) <!-- {docsify-ignore} -->
+> 
+> - Added new tab to the top bar menu. (#15)
+> 
+> - Changed version of database library from v3.0.0 to v3.1.0. (#16)
+> 
+> - Fixed bug where page would refresh after 3 minutes. (#17, #18)
+> 
+> #### v1.0.0 (2021-03-03) <!-- {docsify-ignore} -->
+> 
+> - Added reworked GUI. Enjoy the new design! (#10)
+
+<!-- panels:end -->
+
+## What is it used for
+
+- Users of Wharf who want to see what's new with the product when they consider
+  or already have upgraded their Wharf instance.
+
+- Developers who want to backtrack where something was changed or added without
+  needing to perform a [`git blame`](https://git-scm.com/docs/git-blame).
+
+- Bundling changes, where instead of having lots of small releases with a
+  single changeset in each we bundle up a group of changes into larger releases
+  with 5-10 changes in each.
+
+## Where to find it
+
+In the root directory of the repository, named exactly `CHANGELOG.md`
+
+<!-- panels:start -->
+
+<!-- div:left-panel -->
+
+Examples of repositories **with** a `CHANGELOG.md` file:
+
+- <https://github.com/iver-wharf/wharf-api/blob/master/CHANGELOG.md>
+- <https://github.com/iver-wharf/wharf-api-client-go/blob/master/CHANGELOG.md>
+- <https://github.com/iver-wharf/wharf-core/blob/master/CHANGELOG.md>
+- <https://github.com/iver-wharf/wharf-provider-github/blob/master/CHANGELOG.md>
+- <https://github.com/iver-wharf/wharf-web/blob/master/CHANGELOG.md>
+- *etc.*
+
+<!-- div:right-panel -->
+
+Examples of repositories **without** a `CHANGELOG.md` file:
+
+- <https://github.com/iver-wharf/iver-wharf.github.io>
+- <https://github.com/iver-wharf/rfcs>
+- <https://github.com/iver-wharf/wharf-notes>
+- *etc.*
+
+<!-- panels:end -->

--- a/docs/index.html
+++ b/docs/index.html
@@ -43,17 +43,18 @@
   </script>
   <!-- Additional syntax highlighting -->
   <script src="//cdn.jsdelivr.net/npm/prismjs@1/components/prism-bash.min.js"></script>
-  <script src="//cdn.jsdelivr.net/npm/prismjs@1/components/prism-powershell.min.js"></script>
   <script src="//cdn.jsdelivr.net/npm/prismjs@1/components/prism-batch.min.js"></script>
   <script src="//cdn.jsdelivr.net/npm/prismjs@1/components/prism-diff.min.js"></script>
   <script src="//cdn.jsdelivr.net/npm/prismjs@1/components/prism-docker.min.js"></script>
   <script src="//cdn.jsdelivr.net/npm/prismjs@1/components/prism-go.min.js"></script>
   <script src="//cdn.jsdelivr.net/npm/prismjs@1/components/prism-json.min.js"></script>
-  <script src="//cdn.jsdelivr.net/npm/prismjs@1/components/prism-log.min.js"></script>
-  <script src="//cdn.jsdelivr.net/npm/prismjs@1/components/prism-properties.min.js"></script>
-  <script src="//cdn.jsdelivr.net/npm/prismjs@1/components/prism-yaml.min.js"></script>
-  <script src="//cdn.jsdelivr.net/npm/prismjs@1/components/prism-vim.min.js"></script>
   <script src="//cdn.jsdelivr.net/npm/prismjs@1/components/prism-lisp.min.js"></script>
+  <script src="//cdn.jsdelivr.net/npm/prismjs@1/components/prism-log.min.js"></script>
+  <script src="//cdn.jsdelivr.net/npm/prismjs@1/components/prism-markdown.min.js"></script>
+  <script src="//cdn.jsdelivr.net/npm/prismjs@1/components/prism-powershell.min.js"></script>
+  <script src="//cdn.jsdelivr.net/npm/prismjs@1/components/prism-properties.min.js"></script>
+  <script src="//cdn.jsdelivr.net/npm/prismjs@1/components/prism-vim.min.js"></script>
+  <script src="//cdn.jsdelivr.net/npm/prismjs@1/components/prism-yaml.min.js"></script>
   <!-- Searching -->
   <script src="//cdn.jsdelivr.net/npm/docsify/lib/plugins/search.min.js"></script>
   <!-- Copy code block to clipboard -->


### PR DESCRIPTION
## Summary

New documentation page: `/#/development/changelogs/`

This page goes through what changelogs are and what to expect from them.

## Motivation

I've a different PR to add the docs on how to write them, but I usually find it good to always have a section describing in details what we're working with and how it usually looks, and this intro document got so lengthy that I gave it it's own page.
