### PR TITLE
Deprecated /prob/api/project/cannot-change-group

### DIFF
--- a/docs/prob/_sidebar.md
+++ b/docs/prob/_sidebar.md
@@ -12,7 +12,6 @@
   - [/prob/api/invalid-param-uint](/prob/api/invalid-param-uint.md)
   - [/prob/api/invalid-param](/prob/api/invalid-param.md)
   - [/prob/api/missing-param-string](/prob/api/missing-param-string.md)
-  - [/prob/api/project/cannot-change-group](/prob/api/project/cannot-change-group.md)
   - [/prob/api/project/run/params-deserialize](/prob/api/project/run/params-deserialize.md)
   - [/prob/api/project/run/params-serialize](/prob/api/project/run/params-serialize.md)
   - [/prob/api/project/run/trigger](/prob/api/project/run/trigger.md)
@@ -27,5 +26,9 @@
   - [/prob/provider/composing-provider-data](/prob/provider/composing-provider-data.md)
   - [/prob/provider/fetch-build-definition](/prob/provider/fetch-build-definition.md)
   - [/prob/provider/unexpected-response-format](/prob/provider/unexpected-response-format.md)
+
+  *Deprecated problems*
+
+  - [/prob/api/project/cannot-change-group](/prob/api/project/cannot-change-group.md)
 
 - [Development (of Wharf)](development/)

--- a/docs/prob/api/project/cannot-change-group.md
+++ b/docs/prob/api/project/cannot-change-group.md
@@ -12,6 +12,10 @@
 Once a project has been imported into Wharf, it is not allowed to have its group
 changed.
 
+!> Deprecated: This problem is no longer relevant with the [wharf-api](https://github.com/iver-wharf/wharf-api),
+starting with version v4.2.0. Since v4.2.0, you are allowed to freely update
+both the Wharf group and project names.
+
 <!-- panels:end -->
 
 ## Possible causes


### PR DESCRIPTION
> Depends on: https://github.com/iver-wharf/wharf-api/pull/55

Starting with wharf-api v4.2.0, the Wharf project group can now be changed.

Adding a "deprecated" note instead of removing the problem, to keep clarity.

## Preview

![Screenshot from 2021-09-01 09-16-31](https://user-images.githubusercontent.com/2477952/131628737-0dc31876-cb3d-447c-9c65-9a0b375e0dd1.png)


![Screenshot from 2021-09-01 09-20-09](https://user-images.githubusercontent.com/2477952/131629135-585d57e2-c559-407e-98c4-1c34dc783391.png)
