### PR TITLE
Added docker.destination

### DIFF
--- a/docs/_static/wharf-ci-schema.json
+++ b/docs/_static/wharf-ci-schema.json
@@ -189,6 +189,15 @@
                                 "latest,${GIT_COMMIT},${GIT_TAG}"
                             ]
                         },
+                        "destination": {
+                            "type": "string",
+                            "description": "Full docker image name, including the optional host name. Defaults to using the formula `${registry}/${group}/${REPO_NAME}/${name}`, or simply `${registry}/${group}/${REPO_NAME}` if `${REPO_NAME}` and `${name}` are equal. If set, then the `docker.name`, `docker.group`, and `docker.registry` fields has no effect.",
+                            "examples": [
+                                "quay.io/iver-wharf/wharf-web",
+                                "docker.io/wharfse/helm",
+                                "harbor.local/myproject/myimage"
+                            ]
+                        },
                         "name": {
                             "type": "string",
                             "description": "Docker image name suffix. Defaults to the Wharf step name. Is used when composing the full Docker image name using the formula `${registry}/${group}/${REPO_NAME}/${name}`, or simply `${registry}/${group}/${REPO_NAME}` if `${REPO_NAME}` and `${name}` are equal."

--- a/docs/usage-wharfyml/step-types/docker.md
+++ b/docs/usage-wharfyml/step-types/docker.md
@@ -7,13 +7,14 @@ docker:
   file: src/api/Dockerfile # path to Dockerfile from root of repo
   tag: latest,${GIT_COMMIT},${GIT_TAG}
   # Optional arguments
-  name: # defaults to step name
-  group: default
+  destination: # defaults to "${registry}/${group}/${REPO_NAME}/${name}", or "${registry}/${group}/${REPO_NAME}" if ${REPO_NAME}==${name}
+  name: # defaults to the step name
+  group: # defaults to ${REPO_GROUP} (the Wharf group name)
   context: src/api # context to use when building (defaults to root of repo)
   secret: gitlab-registry # kubernetes secret to use when pushing image
-  registry: https://harbor.local # base url of registry
+  registry: harbor.local # base url of registry, defaults to ${REG_URL}
   append-cert: true # add root CAs to image at /etc/ssl/certs/ca-certificates.crt (defaults to true if REPO_GROUP starts with "default", case insensitive)
-  push: true # push resulting image to registry
+  push: true # push resulting image to registry, defaults to true
   args: # dockerfile building ARGs
     - FIRST_ARG=Value from '.wharf-ci.yml' file!
     - SECOND_ARG=2147483647+1


### PR DESCRIPTION
This new field, `docker.destination`, overrides the docker destination name / full image name for a docker image.

Without this field, the image destination name is composed like so:

```groovy
"{registry}/{group}/{REPO_NAME}/{name}"

or

"{registry}/{group}/{REPO_NAME}" if (REPO_NAME == name)
```

Where `registry`, `group`, and `name` comes from the other `docker` fields, and `REPO_NAME` is the built-in variable.
