### PR TITLE
Added heuristics docs

### DIFF
--- a/docs/development/_sidebar.md
+++ b/docs/development/_sidebar.md
@@ -12,10 +12,15 @@
 
   - Guides
 
+    - [Heuristics](development/heuristics/)
+
+      - [Go](development/heuristics/go.md)
+      - [REST API](development/heuristics/rest-api.md)
+      - [Pull requests](development/heuristics/pull-requests.md)
+
     - [Changelog](development/changelogs/)
 
       - [Writing changelogs](development/changelogs/writing-changelogs.md)
-
       - [Changelog conventions](development/changelogs/changelog-conventions.md)
 
     - [Releasing a new version](development/releasing-a-new-version.md)

--- a/docs/development/heuristics/README.md
+++ b/docs/development/heuristics/README.md
@@ -1,0 +1,4 @@
+# Heuristics
+
+This section is designated to describe the agreed-upon work procedures, coding
+styles and other heuristics that we try to follow throughout our repositories.

--- a/docs/development/heuristics/go.md
+++ b/docs/development/heuristics/go.md
@@ -1,0 +1,155 @@
+# Coding styles: Go
+
+This article is structured like an FAQ because these are taken from meeting
+notes where we came together and decided upon this.
+
+## Idiomatic or borrow practices
+
+Always prefer idiomatic Go. This will be the theme for all the following
+guidelines.
+
+Most of us are used to C# with their Linq queries, inheritance, and such.
+However we do not let this be an excuse, as we do not want to bend the language
+to our will, and in doing so leading to us fighting the language.
+
+## Naming convention
+
+Depends on the use case.
+
+Rule of thumb: **Variable names must be self-explanatory and the length should
+correlate to it's lifetime,** with the exception of method receivers that
+should be really short.
+
+You should not need to look at the regarded implementation in the code block to
+understand what a variable does. Short names fit very well in certain contexts,
+such as `i` is a terrible parameter name, while it's an excellent `for`-loop
+index identifier.
+
+> "Short naming is a principle, not a rule"
+>
+> <https://dave.cheney.net/practical-go/presentations/qcon-china.html#_identifier_length>
+
+### Package names
+
+Short, singular, lowercase, and no delimiters. Keep it to only one word if
+possible. We do not have any "prefix" convention to our packages.
+
+```go
+// Good:
+package stringutil
+package set
+
+// Bad:
+package string_utils
+package wharfApi
+package sets
+```
+
+## "Scout rule"
+
+> "Leave a place better than you found it"
+
+Yes and no. Do not clutter/bloat your pull requests (PR) with too many unrelated
+changes.
+
+Numerous minor or few big changes (that are not strictly required for the PR)
+-> do it in different PR.
+
+## Code formatting
+
+All devs must use [`goimports`](https://pkg.go.dev/golang.org/x/tools/cmd/goimports).
+
+Add it to your editor so it formats your file every time you save it.
+
+This enforces the style of indentation, spacing, wrapping, imports sorting, and
+so on.
+
+## Linting
+
+All our repositories have linting options, which can be triggered via our NPM
+scripts `npm run lint`, or more specifically:
+
+- Markdown: `npm run lint-md` (uses [remark-lint](https://github.com/remarkjs/remark-lint))
+- Go: `npm run lint-go` (uses [revive](https://revive.run/))
+- Angular: `npm run lint-ng` (uses [ng](https://angular.io/cli/lint))
+
+This is enforced by continuous integration on all pull requests, but recommended
+to run them locally to get faster iteration speed.
+
+## Writing tests
+
+Fully optional to write tests, but highly encouraged. Writing the tests first
+followed by the implementation itself (á la TDD) is a good idea to get this
+done, but it's nothing we have as a strict requirement.
+
+### Assertions vs if-statements
+
+We rely on <https://github.com/stretchr/testify> in our tests to write "assert"
+statements instead of "if-statements" for each assertion.
+
+```go
+// Good:
+import "github.com/stretchr/testify/assert"
+
+assert.Equal(t, want, got, "some message")
+
+// Discouraged:
+if want != got {
+  t.Errorf("want %q; got %q. some message", want, got)
+}
+```
+
+This is our exception to our "idiomatic Go" promise. We are too used to testing
+libraries such as [NUnit](https://nunit.org/) that we cannot let go of the
+assertion-based testing style.
+
+### Fake/mock/stub naming
+
+Whatever you want to call them. While the terms do have different semantics, we
+do not bother if you use "mock" everywhere.
+
+## Release notes
+
+Yes, we do collect release notes. No, not automatically from Git commit
+messages. See the section about [Changelog](development/changelogs/)
+
+## Interfaces vs structs
+
+Use structs for value collections, e.g configs.
+
+Use interfaces for behaviors.
+
+Strongly advice to pay extra attention to the ["Interfaces" section of
+"Go Code Review Comments"](https://github.com/golang/go/wiki/CodeReviewComments#interfaces).
+
+## External sources
+
+As in, other sources you as a developer should delve into it before
+contributing to Wharf.
+
+We take a lot of inspiration from the below sources.
+
+### Must read
+
+- Go Code Review Comments (<https://github.com/golang/go/wiki/CodeReviewComments>)
+
+- Effective Go (<https://golang.org/doc/effective_go.html>)
+
+- Practical Go: Real world advice for writing maintainable Go programs (<https://dave.cheney.net/practical-go/presentations/qcon-china.html>)
+
+- GopherCon 2016: Francesc Campoy - Understanding nil (<https://www.youtube.com/watch?v=ynoY2xz-F8s>,
+  *it's a video, so maybe a "must consume" instead of "must read"*)
+
+### Should read
+
+Feel rusty on Go? Go through the tour. Every Wharf developer should complete it.
+
+- https://tour.golang.org/
+
+### Good to read
+
+- Standard Go Project Layout (<https://github.com/golang-standards/project-layout>)
+
+- Clean Code: Smells and Heuristics (<https://moderatemisbehaviour.github.io/clean-code-smells-and-heuristics/>)
+
+- Microsoft REST API Guidelines (<https://github.com/microsoft/api-guidelines#readme>)

--- a/docs/development/heuristics/pull-requests.md
+++ b/docs/development/heuristics/pull-requests.md
@@ -1,0 +1,45 @@
+# Pull requests
+
+## Who resolves discussion threads
+
+Whoever. But do not mark unfinished discussions or unanswered questions as
+resolved.
+
+## Who merges PR
+
+PR author.
+
+In the case of outside contributor, anybody with write access merges it.
+
+## Naming conventions
+
+### Branches
+
+#### Feature branches
+
+`feature/{name-of-feature}`
+
+For new features, bug fixes, or minor chores such as changing the PR templates. 
+Example:
+
+- `feature/fix-progress-bar`
+- `feature/branch-endpoint-rework`
+
+#### Release branches
+
+`release/{version-with-v-prefix}`
+
+See [Releasing a new version](development/releasing-a-new-version). Example:
+
+- `release/v0.3.2`
+- `release/v5.0.0-rc.1`
+
+#### RFC branches
+
+`rfc/{name-of-rfc}`
+
+See [Writing RFCs](https://iver-wharf.github.io/rfcs/guides/writing-rfcs).
+Example:
+
+- `rfc/core-lib-repo`
+- `rfc/project-overrides`

--- a/docs/development/heuristics/rest-api.md
+++ b/docs/development/heuristics/rest-api.md
@@ -1,0 +1,58 @@
+# Coding styles: REST API
+
+This applies to our [wharf-api](https://github.com/iver-wharf/wharf-api) repo.
+
+## Strict REST or relaxed REST
+
+We strive for "strict REST", meaning we try to honor the REST styles as best we
+can.
+
+## Verbs
+
+Do not use `POST` for everything. Instead, use:
+
+- `GET` to read data. Cannot have side effects. Cannot have a request body.
+
+- `POST` to create data. Requesting multiple times should create multiple
+  objects.
+
+- `PUT` to update data by replacing all data. Idempotent: requesting multiple
+  times has the same effect as requesting once.
+
+- `PATCH` to update data surgically by replacing only some fields. Idempotent:
+  requesting multiple times has the same effect as requesting once.
+
+- `DELETE` to remove an object.
+
+## Naming convention
+
+### Path
+
+Singular. Segments correlate to object type name.
+
+```http
+// Good:
+POST /api/project
+GET /api/project/1/branch
+
+// Bad:
+POST /api/projects
+GET /api/project/1/branches
+```
+
+### Path parameters
+
+*(Only applies to implementations and Swagger/OpenAPI specifications)*
+
+"JSON"-formatted, camelCased. ID parameters start with the type name.
+
+```http
+// Good:
+PUT /api/project/{projectId}
+GET /api/build?stage=ALL
+GET /api/build/{buildId}/artifact/{artifactId}
+
+// Bad:
+PUT /api/project/{id}
+GET /api/build?Search_Query=foo+bar
+```

--- a/docs/index.html
+++ b/docs/index.html
@@ -47,6 +47,7 @@
   <script src="//cdn.jsdelivr.net/npm/prismjs@1/components/prism-diff.min.js"></script>
   <script src="//cdn.jsdelivr.net/npm/prismjs@1/components/prism-docker.min.js"></script>
   <script src="//cdn.jsdelivr.net/npm/prismjs@1/components/prism-go.min.js"></script>
+  <script src="//cdn.jsdelivr.net/npm/prismjs@1/components/prism-http.min.js"></script>
   <script src="//cdn.jsdelivr.net/npm/prismjs@1/components/prism-json.min.js"></script>
   <script src="//cdn.jsdelivr.net/npm/prismjs@1/components/prism-lisp.min.js"></script>
   <script src="//cdn.jsdelivr.net/npm/prismjs@1/components/prism-log.min.js"></script>


### PR DESCRIPTION
Our agreed upon heuristics that we try to follow when developing Wharf.

Finally got around to writing this down. This was the last note from our closed-sourced notebook, and we can finally forget about it and only refer to our open-sourced notebooks from now on.

Once this is merged, I will open another PR for a CONTRIBUTING.md file in wharf-api to begin with.

Closes #69
