### PR TITLE
Fixed darker footer text color

### DIFF
--- a/docs/_footer.md
+++ b/docs/_footer.md
@@ -1,5 +1,7 @@
 ---
 
+<div class="footer">
+
 Maintained by [Iver](https://www.iver.com/en).
 Proudly published with [Docsify](https://docsify.js.org).
 Licensed under the [MIT license](https://spdx.org/licenses/MIT.html).
@@ -16,4 +18,6 @@ Licensed under the [MIT license](https://spdx.org/licenses/MIT.html).
 <title>I_S_Neg_RGB</title>
 <g><polygon class="st0" points="0,251.1 0,379 347.7,271.9 347.7,144"></polygon><polygon class="st0" points="245.5,47.2 150.2,0 150.1,128.3 245.5,175.5"></polygon></g>
 </svg>
+</div>
+
 </div>

--- a/docs/_static/site.css
+++ b/docs/_static/site.css
@@ -69,7 +69,7 @@
 
 /* Footer */
 
-footer {
+.footer {
 	color: var(--footer-color);
 }
 


### PR DESCRIPTION
Change in #77 got a bug.

Well more it's like the footer feature in the footer Docsify plugin is buggy.

The `<footer>` container element only exists when opening a page initially, but when switching page, SPA-style, the footer content is just embedded into the page without a `<footer>` element.

## Before

| Navigating to docs home page | Navigating around and then back to docs home page |
| --- | --- |
| ![Screenshot from 2021-11-18 08-42-34](https://user-images.githubusercontent.com/2477952/142373137-a23586a0-0529-46e9-8ff5-67bf3e4118ef.png) | ![Screenshot from 2021-11-18 08-42-51](https://user-images.githubusercontent.com/2477952/142373130-e33cf92c-6c5a-492b-a162-6bf091f104ff.png)

## After

| Navigating to docs home page | Navigating around and then back to docs home page |
| --- | --- |
| ![Screenshot from 2021-11-18 08-45-31](https://user-images.githubusercontent.com/2477952/142373418-a5596518-034b-4038-b127-14a18960294f.png) | ![Screenshot from 2021-11-18 08-49-25](https://user-images.githubusercontent.com/2477952/142373895-b410841d-3589-4de0-9536-7d51231c1f6b.png)
