### PR TITLE
Update Docker port and remove (deprecated) RabbitMQ instructions from developer intro

### DIFF
--- a/docs/development/getting-started.md
+++ b/docs/development/getting-started.md
@@ -124,7 +124,7 @@ the services combined spew out a lot of logs and it's easy to miss if one of
 them has died.
 
 You can find the names of the services (used in `docker-compose build api`)
-in the `docker-compose.yml` file. At the time of writing (2021-05-10), those are
+in the `docker-compose.yml` file. At the time of writing (2021-12-08), those are
 `proxy`, `api`, `provider-gitlab`, `provider-github`, `provider-azuredevops`,
 `db`
 

--- a/docs/development/getting-started.md
+++ b/docs/development/getting-started.md
@@ -141,6 +141,3 @@ in the `docker-compose.yml` file. At the time of writing (2021-05-10), those are
 
   !> The web is disabled by default in the `docker-compose.build.yml`. See how
   to enable it here: [Hot reloading web](development/hot-reloading-web.md)
-
-  - Username: `guest`
-  - Password: `guest`

--- a/docs/development/getting-started.md
+++ b/docs/development/getting-started.md
@@ -137,7 +137,7 @@ in the `docker-compose.yml` file. At the time of writing (2021-05-10), those are
   - `github` provider: <http://localhost:5000/import/github/swagger/index.html>
   - `azuredevops` provider: <http://localhost:5000/import/azuredevops/swagger/index.html>
 
-- Web (if enabled in `docker-compose.build.yml`): <http://localhost:5000/>
+- Web (if enabled in `docker-compose.build.yml`): <http://localhost:/>
 
   !> The web is disabled by default in the `docker-compose.build.yml`. See how
   to enable it here: [Hot reloading web](development/hot-reloading-web.md)

--- a/docs/development/getting-started.md
+++ b/docs/development/getting-started.md
@@ -137,7 +137,7 @@ in the `docker-compose.yml` file. At the time of writing (2021-12-08), those are
   - `github` provider: <http://localhost:5000/import/github/swagger/index.html>
   - `azuredevops` provider: <http://localhost:5000/import/azuredevops/swagger/index.html>
 
-- Web (if enabled in `docker-compose.build.yml`): <http://localhost:/>
+- Web (if enabled in `docker-compose.build.yml`): <http://localhost:4201/>
 
   !> The web is disabled by default in the `docker-compose.build.yml`. See how
   to enable it here: [Hot reloading web](development/hot-reloading-web.md)

--- a/docs/development/getting-started.md
+++ b/docs/development/getting-started.md
@@ -126,7 +126,7 @@ them has died.
 You can find the names of the services (used in `docker-compose build api`)
 in the `docker-compose.yml` file. At the time of writing (2021-05-10), those are
 `proxy`, `api`, `provider-gitlab`, `provider-github`, `provider-azuredevops`,
-`db`, `rabbitmq`
+`db`
 
 ## Accessing locally
 
@@ -141,8 +141,6 @@ in the `docker-compose.yml` file. At the time of writing (2021-05-10), those are
 
   !> The web is disabled by default in the `docker-compose.build.yml`. See how
   to enable it here: [Hot reloading web](development/hot-reloading-web.md)
-
-- RabbitMQ (if enabled in `docker-compose.yml`): <http://localhost:15672/>
 
   - Username: `guest`
   - Password: `guest`


### PR DESCRIPTION
## Summary

Removes instructions for RabbitMQ (now deprecated) from the intro page.

Changes local docker devport to 4201 as per diskussion here - https://github.com/iver-wharf/wharf-docker-compose/pull/13/files

## Motivation

Increases relevance of the article.
