### PR TITLE
Remove "Backlog" project in release PR docs

### DIFF
--- a/docs/development/releasing-a-new-version.md
+++ b/docs/development/releasing-a-new-version.md
@@ -32,7 +32,6 @@
    - Set yourself as assignee
    - Add the label `release`
    - Add at least 2 reviewers
-   - Set the project to the [`Backlog` project](https://github.com/orgs/iver-wharf/projects/1)
 
    In the PR description, you add all the notes from the `CHANGELOG.md` for the
    respective version, something like so:


### PR DESCRIPTION
The "Backlog" project was removed because it was unused.

This was the only reference of it I could find in the docs
