### PR TITLE
Moved linting to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: \
+.PHONY: deps \
 	lint lint-md \
 	lint-fix lint-md-fix
 

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,15 @@
+.PHONY: \
+	lint lint-md \
+	lint-fix lint-md-fix
+
+deps:
+	npm install
+
+lint: lint-md
+lint-fix: lint-md-fix
+
+lint-md:
+	npx remark . .github
+
+lint-md-fix:
+	npx remark . .github -o

--- a/README.md
+++ b/README.md
@@ -23,18 +23,23 @@ via GitHub Pages over at <https://iver-wharf.github.io/>.
 
 4. Visit <http://localhost:3000>
 
-## Linting markdown
+## Linting
 
-Requires Node.js (npm) to be installed: <https://nodejs.org/en/download/>
+You can lint all of the above at the same time by running:
 
 ```sh
-npm install
+make lint
 
-npm run lint
+make lint-md # only lint Markdown files
+```
 
-# Some errors can be fixed automatically. Keep in mind that this updates the
-# files in place.
-npm run lint-fix
+Some errors can be fixed automatically. Keep in mind that this updates the
+files in place.
+
+```sh
+make lint-fix
+
+make lint-fix-md # only lint and fix Markdown files
 ```
 
 ---

--- a/package.json
+++ b/package.json
@@ -1,8 +1,6 @@
 {
   "scripts": {
-    "start": "docsify serve docs",
-    "lint": "remark .",
-    "lint-fix": "remark . -o"
+    "start": "docsify serve docs"
   },
   "devDependencies": {
     "docsify-cli": "^4.4.3",


### PR DESCRIPTION
## Summary

- Added targets to `Makefile` for linting
- Removed linting from NPM scripts in `package.json`
- Simplified linting docs

## Motivation

Moves focus from relying on NPM for all linting stuff over to Makefile.

Based on https://github.com/iver-wharf/wharf-cmd/pull/31
