### PR TITLE
Fixed lint-fix Makefile targets ordering

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,15 +1,15 @@
 .PHONY: deps \
 	lint lint-md \
-	lint-fix lint-md-fix
+	lint-fix lint-fix-md
 
 deps:
 	npm install
 
 lint: lint-md
-lint-fix: lint-md-fix
+lint-fix: lint-fix-md
 
 lint-md:
 	npx remark . .github
 
-lint-md-fix:
+lint-fix-md:
 	npx remark . .github -o


### PR DESCRIPTION
## Summary

- Renamed Makefile targets from `lint-{lang}-fix` to `lint-fix-{lang}` to stay consistent with the README.md

## Motivation

Having the lang part last makes most sense to me as it lets the most specific part be last in the string, sort of like reverse domain names.
